### PR TITLE
fix: resolve interactive pager issue in workflow helper PR status

### DIFF
--- a/scripts/workflow-helper.sh
+++ b/scripts/workflow-helper.sh
@@ -142,7 +142,7 @@ case "$1" in
         
     "pr-status"|"prs")
         echo "${GREEN}📋 Pull Request Status${NC}"
-        gh pr list --state open
+        PAGER="" gh pr list --state open
         ;;
         
     "pr-view"|"prv")
@@ -226,7 +226,7 @@ case "$1" in
             
             print_section "📋 Pull Requests"
             if command -v gh &> /dev/null; then
-                gh pr list --state open --limit 5 2>/dev/null || echo "No open PRs or GitHub CLI not authenticated"
+                PAGER="" gh pr list --state open --limit 5 2>/dev/null || echo "No open PRs or GitHub CLI not authenticated"
             else
                 echo "GitHub CLI not installed"
             fi
@@ -269,7 +269,7 @@ case "$1" in
             
             print_section "📋 Pull Requests"
             if command -v gh &> /dev/null; then
-                gh pr list --state all --limit 10 2>/dev/null || echo "No PRs or GitHub CLI not authenticated"
+                PAGER="" gh pr list --state all --limit 10 2>/dev/null || echo "No PRs or GitHub CLI not authenticated"
             else
                 echo "GitHub CLI not installed"
             fi


### PR DESCRIPTION
🔧 Fixed the 'less' interactive dialog issue in workflow helper:

**Problem:**
- 'gh pr list' commands were triggering interactive pager (less)
- Status command would hang waiting for user input
- Pull requests section would show raw log output instead of PR data

**Solution:**
- Added PAGER="" prefix to all 'gh pr list' commands
- Prevents GitHub CLI from using interactive pager
- Ensures clean output for both status and pr-status commands

**Fixed Commands:**
- ✅ ./scripts/workflow-helper.sh status (now shows PRs properly)
- ✅ ./scripts/workflow-helper.sh pr-status (no more hanging)
- ✅ ./scripts/workflow-helper.sh export-status (clean export)

**Files Changed:**
- scripts/workflow-helper.sh (3 gh pr list commands fixed)

Now the workflow helper properly displays pull request information without getting stuck in interactive mode!